### PR TITLE
fix: Add root-level .claude-plugin for GitHub marketplace installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "aissist-marketplace",
+  "owner": {
+    "name": "Albert Nahas"
+  },
+  "plugins": [
+    {
+      "name": "aissist",
+      "description": "AI-powered personal assistant for tracking goals, history, reflections, and context with semantic recall",
+      "version": "1.4.1",
+      "author": {
+        "name": "Albert Nahas"
+      },
+      "source": "./aissist-plugin"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` at the repository root
- References the existing plugin at `./aissist-plugin`

## Problem

When running `aissist init --global` and choosing to integrate with Claude Code, the plugin installation fails with:

```
✖ Failed to install plugin
✗ Failed to add marketplace: Marketplace file not found at ~/.claude/plugins/marketplaces/albertnahas-aissist/.claude-plugin/marketplace.json
```

This happens because `claude plugin marketplace add albertnahas/aissist` looks for `.claude-plugin/marketplace.json` at the **repository root**, but it only existed in `aissist-plugin/.claude-plugin/`.

## Solution

Add a root-level `.claude-plugin/marketplace.json` that references `./aissist-plugin` as the plugin source. This allows both installation methods to work:

- `claude plugin marketplace add albertnahas/aissist` (GitHub - for npm users)
- `claude plugin marketplace add /path/to/aissist-plugin` (local - for developers)

## Test plan

- [ ] Run `claude plugin marketplace add albertnahas/aissist` after merging
- [ ] Verify `claude plugin install aissist` succeeds
- [ ] Test `aissist init --global` with Claude Code integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)